### PR TITLE
Update Templates, add option for custom 'tip' and 'withdraw' body text

### DIFF
--- a/nyantip-sample.yml
+++ b/nyantip-sample.yml
@@ -17,6 +17,8 @@ coin:
     transaction_fee: "0.0001"
     symbol: 'Ɲ'
     unit: nya
+tip_message_body_url_encoded: "tip%20u/USERNAME%20AMOUNT"
+withdraw_message_body_url_encoded: "withdraw%20ADDRESS%20AMOUNT"
 commands:
     accept: \Aaccept$
     decline: \Adecline$

--- a/nyantip/templates/confirmation.tpl
+++ b/nyantip/templates/confirmation.tpl
@@ -4,14 +4,7 @@
 {%   set arrow_formatted = "[->]({}{})".format(explorer["transaction"], transaction_id) %}
 {%   set destination_formatted = "[{}]({}{})".format(destination, explorer["address"], destination) %}
 {% else: %}
-{%   set arrow_formatted = "->" %}
-{%   set destination_formatted = "u/{}^[[stats]]({}_{})".format(destination, stats_url, destination) %}
+{%   set arrow_formatted = "tipped" %}
+{%   set destination_formatted = "u/{}".format(destination) %}
 {% endif %}
-__[{{ title }}]__
-
-u/{{ message.author }}^[[stats]]({{ stats_url }}_{{ message.author }}) {{ arrow_formatted }} {{ destination_formatted }}
-
-__{{ amount_formatted }}__
-
-^[[help]]({{ "/r/{}/wiki/{}".format(config["reddit"]["subreddit"], "index") }})
-^[[stats]]({{ stats_url }})
+**^([{{ title }}]) u/{{ message.author }} {{ arrow_formatted }} {{ destination_formatted }} __{{ amount_formatted }}__** |[ wiki ]({{ "/r/{}/wiki/{}".format(config["reddit"]["subreddit"], "index") }}) | [ stats ]({{ stats_url }})|

--- a/nyantip/templates/footer.tpl
+++ b/nyantip/templates/footer.tpl
@@ -8,8 +8,8 @@
 {% set info_url = compose_url.format(bot, "info", "info") %}
 {% set stats_global_format = " ^[[global_stats]]({})".format(wiki_url.format("stats")) %}
 {% set stats_user_format = " **^[[your_stats]]({}_{})**".format(wiki_url.format("stats"), message.author) %}
-{% set tip_url = compose_url.format(bot, "tip", "tip%20u/USERNAME%20AMOUNT") %}
-{% set withdrawl_url = compose_url.format(bot, "withdraw", "withdraw%20ADDRESS%20AMOUNT") %}
+{% set tip_url = compose_url.format(bot, "tip", config["tip_message_body_url_encoded"]) %}
+{% set withdrawl_url = compose_url.format(bot, "withdraw", config["withdraw_message_body_url_encoded"]) %}
 *****
 
 links|&nbsp;

--- a/nyantip/templates/info.tpl
+++ b/nyantip/templates/info.tpl
@@ -3,7 +3,7 @@ Hello u/{{ action.source }}! Here is your account info:
 coin|deposit address|balance
 :---|:---|---:
 {% set name_format = "{} ({})".format(config["coin"]["name"], config["coin"]["unit"].upper()) %}
-{% set address_format = "{} ^[[ex]]({}{}) ^[[qr]]({}{})".format(address, config["coin"]["explorer"]["address"], address, config["qr_url"], address) %}
+{% set address_format = "{} ^[[Blockchain_Explorer]]({}{}) ^[[QR_Code]]({}{})".format(address, config["coin"]["explorer"]["address"], address, config["qr_url"], address) %}
 {% set balance_format = "%.6f" % balance %}
 __{{ name_format }}__|{{ address_format }}|__{{ balance_format }}__
 &nbsp;|&nbsp;|&nbsp;


### PR DESCRIPTION
1. Expand abbreviations 'ex' and 'qr' in info template.

![image](https://github.com/bboe/nyantip/assets/143240103/93c59c46-e11d-4039-9b0f-974cbc93e95a)

2. Add 2 new variables in config file to set custom body messages for tip and withdraw commands. This is so when you change the regex for these messages, you can make the 'tip' and 'withdraw' links in the info templates match your regex.

`tip_message_body_url_encoded`
`withdraw_message_body_url_encoded`

3. Simplify comment verification post. 

![image](https://github.com/bboe/nyantip/assets/143240103/6bf7e2b5-140a-496e-b496-32467f50c9f5)


