### PR TITLE
Add accept and decline to pending tip message

### DIFF
--- a/nyantip/actions.py
+++ b/nyantip/actions.py
@@ -573,7 +573,7 @@ def actions(
             message = nyantip.reddit.inbox.message(row["message_id"])
 
         if message.author is None:
-            log.warning("Cannot process item missing author. %r", message)
+            logger.warning("Cannot process item missing author. %r", message)
             continue
 
         results.append(

--- a/nyantip/templates/confirmation.tpl
+++ b/nyantip/templates/confirmation.tpl
@@ -7,4 +7,15 @@
 {%   set arrow_formatted = "tipped" %}
 {%   set destination_formatted = "u/{}".format(destination) %}
 {% endif %}
-**^([{{ title }}]) u/{{ message.author }} {{ arrow_formatted }} {{ destination_formatted }} __{{ amount_formatted }}__** |[ wiki ]({{ "/r/{}/wiki/{}".format(config["reddit"]["subreddit"], "index") }}) | [ stats ]({{ stats_url }})|
+{% if title|lower == "pending accept" %}
+{%   set firstLinkText = "accept" %}
+{%   set firstLinkUrl = "https://www.reddit.com/message/compose?to=pepetipbot&subject=accept&message=accept" %}
+{%   set secondLinkText = "decline" %}
+{%   set secondLinkUrl = "https://www.reddit.com/message/compose?to=pepetipbot&subject=decline&message=decline" %}
+{% else: %}
+{%   set firstLinkText = "wiki" %}
+{%   set firstLinkUrl = "/r/{}/wiki/{}".format(config["reddit"]["subreddit"], "index") %}
+{%   set secondLinkText = "stats" %}
+{%   set secondLinkUrl = stats_url %}
+{% endif %}
+**^([{{ title }}]) u/{{ message.author }} {{ arrow_formatted }} {{ destination_formatted }} __{{ amount_formatted }}__** |[ {{ firstLinkText }} ]({{ firstLinkUrl }}) | [ {{ secondLinkText }} ]({{ secondLinkUrl }})|


### PR DESCRIPTION
Added "accept" and "decline" directly to pending tip messages to make it easier for new users to accept tips and create their account

![image](https://github.com/bboe/nyantip/assets/143240103/56aaeaa1-9e7b-43aa-99ed-08aec637892a)
